### PR TITLE
OTA server web page fixies

### DIFF
--- a/ota.lua
+++ b/ota.lua
@@ -35,6 +35,10 @@ local pl = nil;
 local sv=net.createServer(net.TCP, 10) 
 
 sv:listen(80,function(conn)
+  conn:on("sent", function(conn, pl)
+    conn:close()
+    collectgarbage()
+  end)
   conn:on("receive", function(conn, pl) 
     local payload = pl;
     if string.sub(pl, 0, 9) == "**LOAD**\n"  then
@@ -51,8 +55,6 @@ sv:listen(80,function(conn)
       print("HTTP : default page")
       conn:send(exec_template("page.tmpl"))
     end
-    conn:close()
-    collectgarbage()
   end)
 end)
 print("Server running...")

--- a/page.tmpl
+++ b/page.tmpl
@@ -1,3 +1,4 @@
+<head><link rel="icon" href="data:;base64,="></head>
 <b>MQTT topic ID : </b>{{$ MQTT_MAINTOPIC }}<br>
 <b>Status : </b>{{$ gpio.read(GPIO_SWITCH) }}
 


### PR DESCRIPTION
1) OTA server closes conection right after send so it can't show web page - Fixed;
2) Response for standart favicon.ico request is made with default page data - Fixed.